### PR TITLE
Add defaults for SGML-like languages (HTML, XML...)

### DIFF
--- a/README.org
+++ b/README.org
@@ -70,6 +70,7 @@ It's in [[https://melpa.org][MELPA]], so if you have that in your package lists,
 (require 'smart-hungry-delete)
 (smart-hungry-delete-add-default-hooks)
 (global-set-key (kbd "<backspace>") 'smart-hungry-delete-backward-char)
+(global-set-key (kbd "<delete>") 'smart-hungry-delete-backward-char)
 (global-set-key (kbd "C-d") 'smart-hungry-delete-forward-char)
 #+end_src
 
@@ -80,6 +81,7 @@ If you use =use-package=:
 (use-package smart-hungry-delete
   :ensure t
   :bind (("<backspace>" . smart-hungry-delete-backward-char)
+            ("<delete>" . smart-hungry-delete-forward-char)
 		 ("C-d" . smart-hungry-delete-forward-char))
   :defer nil ;; dont defer so we can add our functions to hooks 
   :config (smart-hungry-delete-add-default-hooks)

--- a/smart-hungry-delete.el
+++ b/smart-hungry-delete.el
@@ -189,7 +189,7 @@ With PREFIX just delete one char."
               fallback 'delete-char)
         )
     (if (region-active-p)
-        (delete-region (region-beginning) (region-end))
+        (kill-region (region-beginning) (region-end) t)
       (if (funcall check smart-hungry-delete-char-kill-regexp)
           (let* ((start (funcall kill-end-match 0))
                  (kill-start (if (smart-hungry-delete-char-trigger start (point))

--- a/smart-hungry-delete.el
+++ b/smart-hungry-delete.el
@@ -96,6 +96,11 @@ completely deleted."
         (smart-hungry-delete-add-regexps-left-right "<" ">")
         (add-to-list 'smart-hungry-delete-char-trigger-killall-regexps '("." . ":"))))
 
+(defun smart-hungry-delete-default-sgml-mode-common-hook ()
+  "Add some good default regexps for `sgml-mode`-likes."
+  (progn
+        (smart-hungry-delete-add-regexps-left-right "<" ">")))
+
 
 (defun smart-hungry-delete-default-text-mode-hook ()
   "Add some good default regexps for `text-mode`."
@@ -110,6 +115,8 @@ completely deleted."
   (add-hook 'prog-mode-hook 'smart-hungry-delete-default-prog-mode-hook)
   (add-hook 'c-mode-common-hook 'smart-hungry-delete-default-c-mode-common-hook)
   (add-hook 'python-mode-hook 'smart-hungry-delete-default-c-mode-common-hook)
+  (add-hook 'sgml-mode-hook 'smart-hungry-delete-default-sgml-mode-common-hook)
+  (add-hook 'nxml-mode-hook 'smart-hungry-delete-default-sgml-mode-common-hook)
   (add-hook 'text-mode-hook 'smart-hungry-delete-default-text-mode-hook))
 
 ;;;###autoload


### PR DESCRIPTION
I miss deletion of all spaces in modes with tags (like HTML, XML...)

In cases like `<    tag       >` I think a hungry delete should remove all spaces and get `<tag>`