### PR TITLE
Fix rectangular region kill

### DIFF
--- a/smart-hungry-delete.el
+++ b/smart-hungry-delete.el
@@ -182,7 +182,7 @@ With PREFIX just delete one char."
               fallback 'delete-char)
         )
     (if (region-active-p)
-        (delete-region (region-beginning) (region-end))
+        (kill-region (region-beginning) (region-end) t)
       (if (funcall check smart-hungry-delete-char-kill-regexp)
           (let* ((start (funcall kill-end-match 0))
                  (kill-start (if (smart-hungry-delete-char-trigger start (point))


### PR DESCRIPTION
When deleting a rectangular region, the hungry delete removes the lines between the start and end of the region, including wholes lines between them.
This PR fix this bug and also save the deleted region to the kill ring.